### PR TITLE
Fix crash on window resize

### DIFF
--- a/src/terminalwidget.cpp
+++ b/src/terminalwidget.cpp
@@ -687,6 +687,8 @@ void TerminalWidget::setTerminalSize(int rows, int cols) {
         ws.ws_col = cols;
         ioctl(m_ptyMaster, TIOCSWINSZ, &ws);
     }
+
+    clampCursor();
     viewport()->update();
 }
 


### PR DESCRIPTION
## Summary
- clamp cursor position when terminal size changes
